### PR TITLE
Udates fastify, plugin-meta

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,4 +57,7 @@ function fastifyAcceptHeader (fastify, options, done) {
   done()
 }
 
-module.exports = fp(fastifyAcceptHeader, '>= 0.35.0')
+module.exports = fp(fastifyAcceptHeader, {
+  fastify: '>= 0.39.1',
+  name: 'fastify-accepts'
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "devDependencies": {
     "coveralls": "^2.13.1",
-    "fastify": "^0.36.0",
+    "fastify": "^0.39.1",
     "pre-commit": "^1.2.2",
     "request": "2.83.0",
     "snazzy": "^7.0.0",


### PR DESCRIPTION
- Updates to fasify@0.39.1
- Adds `name` property to plugin-meta. see: https://github.com/fastify/fastify-plugin/issues/17#issuecomment-355972265

coveralls@3.0.0 has unsolved issues, therefore it is not included.