### PR TITLE
Replaced deprecated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Add accepts parser to fastify
 
 ## Usage
 
-```js
+```nodejs
 const fastify = require('fastify')
-const Boom = require('boom')
+const Boom = require('@hapi/boom')
 
 fastify.register(require('@fastify/accepts'))
 
@@ -38,7 +38,7 @@ See [accepts package](https://www.npmjs.com/package/accepts) for all available A
 
 This plugin adds to `Request` object all `Accepts` object methods.
 
-```js
+```nodejs
 fastify.post('/', function (req, reply) {
   req.charset(['utf-8'])
   req.charsets()

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add accepts parser to fastify
 
 ## Usage
 
-```nodejs
+```js
 const fastify = require('fastify')
 const Boom = require('@hapi/boom')
 
@@ -38,7 +38,7 @@ See [accepts package](https://www.npmjs.com/package/accepts) for all available A
 
 This plugin adds to `Request` object all `Accepts` object methods.
 
-```nodejs
+```js
 fastify.post('/', function (req, reply) {
   req.charset(['utf-8'])
   req.charsets()


### PR DESCRIPTION
`boom` is now deprecated. I replaced it with `@hapi/boom`.