### PR TITLE
fix(index): check `options.decorateReply` is a boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function fastifyAccepts (fastify, options, done) {
     })
   })
 
-  if (options.decorateReply) {
+  if (options.decorateReply === true) {
     fastify.decorateReply('requestAccepts', replyAcceptMethod)
 
     methodNames.forEach(methodName => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -109,7 +109,7 @@ type FastifyAccepts = FastifyPluginCallback<fastifyAccepts.FastifyAcceptsOptions
 
 declare namespace fastifyAccepts {
   export interface FastifyAcceptsOptions {
-    decorateReply: boolean
+    decorateReply?: boolean | undefined
   }
 
   export const fastifyAccepts: FastifyAccepts

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,6 +4,8 @@ import accepts from '..'
 const app = fastify()
 
 app.register(accepts)
+app.register(accepts, { decorateReply: true })
+app.register(accepts, { decorateReply: false })
 
 app.get('/', (request, reply) => {
   const accept = request.accepts()


### PR DESCRIPTION
The types state that the value should be a boolean, but the plugin is only checking if it is truthy.
This PR updates the `if` condition to explicitly check it is boolean.

Likewise, the PR updates the types to reflect that `decorateReply` is optional.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
