### PR TITLE
ci: set permissions at workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    permissions:
-      contents: write
-      pull-requests: write
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5
     with:
       license-check: true

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Add an accepts parser to Fastify.
 
 | Plugin version | Fastify version |
 | ---------------|-----------------|
-| `^5.x`         | `^5.x`          |
+| `>=5.x`        | `^5.x`          |
 | `^4.x`         | `^4.x`          |
-| `^2.x`         | `^3.x`          |
+| `>=2.x <4.x`   | `^3.x`          |
 | `^1.x`         | `^2.x`          |
 | `^1.x`         | `^1.x`          |
 


### PR DESCRIPTION
This is a batch PR. This change stops security tools like step-security from complaining.