### PR TITLE
chore(index): add jsdoc types

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const methodNames = [
   'type', 'types'
 ]
 
+/** @this {import('fastify').FastifyRequest} */
 function acceptsMethod () {
   if (!this.raw[acceptsObjectSymbol]) {
     this.raw[acceptsObjectSymbol] = accepts(this.raw)
@@ -20,6 +21,7 @@ function acceptsMethod () {
   return this.raw[acceptsObjectSymbol]
 }
 
+/** @this {import('fastify').FastifyReply} */
 function replyAcceptMethod () {
   if (!this.request[acceptsObjectSymbol]) {
     this.request[acceptsObjectSymbol] = accepts(this.request.raw)
@@ -27,6 +29,7 @@ function replyAcceptMethod () {
   return this.request[acceptsObjectSymbol]
 }
 
+/** @type {typeof import('./types/index').fastifyAccepts} */
 function fastifyAccepts (fastify, options, done) {
   fastify.decorateRequest('accepts', acceptsMethod)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,6 +6,8 @@ const fastifyAccepts = require('..')
 
 const Fastify = require('fastify')
 
+/** @typedef {import('node:test').TestContext} TestContext */
+
 const testCases = [
   {
     name: 'request - no header',
@@ -88,7 +90,7 @@ const testCases = [
   }
 ]
 
-test('accept header', async t => {
+test('accept header', async (/** @type {TestContext} */ t) => {
   t.plan(testCases.length)
 
   const fastify = Fastify()
@@ -120,7 +122,7 @@ test('accept header', async t => {
   const BASE_URL = `http://localhost:${fastify.server.address().port}`
 
   for (const testCase of testCases) {
-    await t.test(testCase.name, async (t) => {
+    await t.test(testCase.name, async (/** @type {TestContext} */ t) => {
       t.plan(1)
 
       const result = await fetch(`${BASE_URL}${testCase.url}`, {
@@ -133,7 +135,7 @@ test('accept header', async t => {
   }
 })
 
-test('no reply decorator', async function (t) {
+test('no reply decorator', async function (/** @type {TestContext} */ t) {
   const fastify = Fastify()
   fastify.register(fastifyAccepts, { decorateReply: false })
   await fastify.ready()


### PR DESCRIPTION
This PR adds JSDoc blocks to all functions to improve static analysis. We had some success with this in https://github.com/fastify/secure-json-parse/pull/154 so seeing if it shakes anything out in other repos.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
