### PR TITLE
refactor(index): name anonymous functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,23 +34,31 @@ function fastifyAccepts (fastify, options, done) {
   fastify.decorateRequest('accepts', acceptsMethod)
 
   methodNames.forEach(methodName => {
-    fastify.decorateRequest(methodName, function (arr) {
-      const acceptsObject = this.accepts()
-      if (arguments.length === 0) return acceptsObject[methodName]()
-      return acceptsObject[methodName](arr)
-    })
+    // Defining methods this way to ensure named functions show in stack traces
+    fastify.decorateRequest(methodName, {
+      [methodName]: function (arr) {
+        const acceptsObject = this.accepts()
+        if (arguments.length === 0) return acceptsObject[methodName]()
+        return acceptsObject[methodName](arr)
+      }
+    }[methodName])
   })
+      
 
   if (options.decorateReply === true) {
     fastify.decorateReply('requestAccepts', replyAcceptMethod)
 
     methodNames.forEach(methodName => {
       const capitalizedMethodName = methodName.replace(/(?:^|\s)\S/gu, a => a.toUpperCase())
-      fastify.decorateReply('request' + capitalizedMethodName, function (arr) {
-        const acceptsObject = this.requestAccepts()
-        if (arguments.length === 0) return acceptsObject[methodName]()
-        return acceptsObject[methodName](arr)
-      })
+      const replyMethodName = 'request' + capitalizedMethodName
+      // Defining methods this way to ensure named functions show in stack traces
+      fastify.decorateReply(replyMethodName, {
+        [replyMethodName]: function (arr) {
+          const acceptsObject = this.requestAccepts()
+          if (arguments.length === 0) return acceptsObject[methodName]()
+          return acceptsObject[methodName](arr)
+        }
+      }[replyMethodName])
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ function fastifyAccepts (fastify, options, done) {
       }
     }[methodName])
   })
-      
 
   if (options.decorateReply === true) {
     fastify.decorateReply('requestAccepts', replyAcceptMethod)

--- a/index.js
+++ b/index.js
@@ -50,14 +50,15 @@ function fastifyAccepts (fastify, options, done) {
     methodNames.forEach(methodName => {
       const capitalizedMethodName = methodName.replace(/(?:^|\s)\S/gu, a => a.toUpperCase())
       const replyMethodName = 'request' + capitalizedMethodName
+      const acceptsMethodName = 'accepts' + capitalizedMethodName
       // Defining methods this way to ensure named functions show in stack traces
       fastify.decorateReply(replyMethodName, {
-        [replyMethodName]: function (arr) {
+        [acceptsMethodName]: function (arr) {
           const acceptsObject = this.requestAccepts()
           if (arguments.length === 0) return acceptsObject[methodName]()
           return acceptsObject[methodName](arr)
         }
-      }[replyMethodName])
+      }[acceptsMethodName])
     })
   }
 


### PR DESCRIPTION
Helps with debugging.

See https://github.com/fastify/otel/issues/110

Before:

<img width="1228" height="260" alt="image" src="https://github.com/user-attachments/assets/e7c6914e-81c7-44b8-baec-ac4c81a0980a" />

After:

<img width="1223" height="227" alt="image" src="https://github.com/user-attachments/assets/b7e28978-59bd-46d9-abe8-1b900ef738f9" />


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
