### PR TITLE
perf(index): use for loop over foreach

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function fastifyAccepts (fastify, options, done) {
   fastify.decorateRequest('accepts', acceptsMethod)
 
   const methodNamesLength = methodNames.length
-  for (let i = 0; i < methodNamesLength; i+=1) {
+  for (let i = 0; i < methodNamesLength; i += 1) {
     const methodName = methodNames[i]
     // Defining methods this way to ensure named functions show in stack traces
     fastify.decorateRequest(methodName, {
@@ -44,12 +44,12 @@ function fastifyAccepts (fastify, options, done) {
         return acceptsObject[methodName](arr)
       }
     }[methodName])
-  })
+  }
 
   if (options.decorateReply === true) {
     fastify.decorateReply('requestAccepts', replyAcceptMethod)
 
-    for (let i = 0; i < methodNamesLength; i+=1) {
+    for (let i = 0; i < methodNamesLength; i += 1) {
       const methodName = methodNames[i]
       const capitalizedMethodName = methodName.replace(/(?:^|\s)\S/gu, a => a.toUpperCase())
       const replyMethodName = 'request' + capitalizedMethodName
@@ -62,7 +62,7 @@ function fastifyAccepts (fastify, options, done) {
           return acceptsObject[methodName](arr)
         }
       }[acceptsMethodName])
-    })
+    }
   }
 
   done()

--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ function replyAcceptMethod () {
 function fastifyAccepts (fastify, options, done) {
   fastify.decorateRequest('accepts', acceptsMethod)
 
-  methodNames.forEach(methodName => {
+  const methodNamesLength = methodNames.length
+  for (let i = 0; i < methodNamesLength; i+=1) {
+    const methodName = methodNames[i]
     // Defining methods this way to ensure named functions show in stack traces
     fastify.decorateRequest(methodName, {
       [methodName]: function (arr) {
@@ -47,7 +49,8 @@ function fastifyAccepts (fastify, options, done) {
   if (options.decorateReply === true) {
     fastify.decorateReply('requestAccepts', replyAcceptMethod)
 
-    methodNames.forEach(methodName => {
+    for (let i = 0; i < methodNamesLength; i+=1) {
+      const methodName = methodNames[i]
       const capitalizedMethodName = methodName.replace(/(?:^|\s)\S/gu, a => a.toUpperCase())
       const replyMethodName = 'request' + capitalizedMethodName
       const acceptsMethodName = 'accepts' + capitalizedMethodName


### PR DESCRIPTION
Similar to https://github.com/fastify/fastify-sensible/pull/138, this PR replaces a `forEach` loop with a traditional for loop with a cached length, which cuts down on function overhead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
